### PR TITLE
Reduce device permissions

### DIFF
--- a/io.github.ihhub.Fheroes2.yaml
+++ b/io.github.ihhub.Fheroes2.yaml
@@ -17,7 +17,7 @@ finish-args:
   # Network for demo download
   - --share=network
   # The minimum required version of installed Flatpak.
-  - --require-version=1.16
+  - --require-version=1.16.0
 command: fheroes2.sh
 rename-appdata-file: fheroes2.metainfo.xml
 rename-desktop-file: fheroes2.desktop

--- a/io.github.ihhub.Fheroes2.yaml
+++ b/io.github.ihhub.Fheroes2.yaml
@@ -16,6 +16,8 @@ finish-args:
   - --talk-name=org.freedesktop.FileManager1.*
   # Network for demo download
   - --share=network
+  # The minimum required version of installed Flatpak.
+  --require-version=1.16
 command: fheroes2.sh
 rename-appdata-file: fheroes2.metainfo.xml
 rename-desktop-file: fheroes2.desktop

--- a/io.github.ihhub.Fheroes2.yaml
+++ b/io.github.ihhub.Fheroes2.yaml
@@ -3,7 +3,10 @@ runtime: org.freedesktop.Platform
 runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 finish-args:
-  - --device=all
+  # Input devices such as controllers
+  - --device=input
+  # Direct Rendering Interface. Necessary for GL.
+  - --device=dri
   # X11 + XShm access
   - --share=ipc
   - --socket=x11

--- a/io.github.ihhub.Fheroes2.yaml
+++ b/io.github.ihhub.Fheroes2.yaml
@@ -17,7 +17,7 @@ finish-args:
   # Network for demo download
   - --share=network
   # The minimum required version of installed Flatpak.
-  --require-version=1.16
+  - --require-version=1.16
 command: fheroes2.sh
 rename-appdata-file: fheroes2.metainfo.xml
 rename-desktop-file: fheroes2.desktop


### PR DESCRIPTION
As highlighted [here](https://github.com/ihhub/fheroes2/issues/9409) we need to reduce the scope of devices the application uses. As you can see on this screenshot Flatpak itself highlights the problem:
![image](https://github.com/user-attachments/assets/062bd941-6180-4d73-81e0-1177ed17f3d5)

This pull request attempts to reduce the scope preserving the original required access to devices.